### PR TITLE
Bump version & changelog for #6

### DIFF
--- a/package/yast2-rdp.changes
+++ b/package/yast2-rdp.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb  5 14:07:24 UTC 2018 - knut.anderssen@suse.com
+
+- Replace SuSEFirewall2 by firewalld (fate#323460)
+- 4.0.0
+
+-------------------------------------------------------------------
 Thu Aug  4 13:57:21 UTC 2016 - hguo@suse.com
 
 - Remove unnecessary files from source archive and fix build errors.

--- a/package/yast2-rdp.spec
+++ b/package/yast2-rdp.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-rdp
-Version:        3.1.3
+Version:        4.0.0
 Release:        0
 License:        GPL-2.0
 Group:          System/YaST
@@ -24,9 +24,13 @@ Summary:        Setup Remote Desktop Protocol service for remote administration
 URL:            https://www.suse.com
 Source0:        %{name}-%{version}.tar.bz2
 BuildArch:      noarch
-BuildRequires:  perl-XML-Writer update-desktop-files yast2 yast2-testsuite yast2-network
+# SuSEFirewall2 replaced by firewalld (fate#323460)
+BuildRequires:  yast2 >= 4.0.39
+BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite yast2-network
 BuildRequires:  yast2-devtools
-Requires:       yast2 yast2-ruby-bindings
+# SuSEFirewall2 replaced by firewalld (fate#323460)
+Requires:       yast2 >= 4.0.39
+Requires:       yast2-ruby-bindings
 
 %description
 Configure RDP (remote desktop protocol) daemon to allow remote system administration.


### PR DESCRIPTION
It adds version bump and changelog for #6 

- [Trello Card](https://trello.com/c/99OkErr6/1093-8-firewall-firewalld-is-the-new-susefirewall-cwm)