### PR TITLE
Remove network dependency

### DIFF
--- a/package/yast2-rdp.changes
+++ b/package/yast2-rdp.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 18 14:05:05 UTC 2019 - knut.anderssen@suse.com
+
+- Remove network dependency completely
+- 4.1.1
+
+-------------------------------------------------------------------
 Tue Feb 26 12:50:07 UTC 2019 - José Iván López González <jlopez@suse.com>
 
 - Version bump (bsc#1124009)

--- a/package/yast2-rdp.spec
+++ b/package/yast2-rdp.spec
@@ -26,7 +26,7 @@ Source0:        %{name}-%{version}.tar.bz2
 BuildArch:      noarch
 # SuSEFirewall2 replaced by firewalld (fate#323460)
 BuildRequires:  yast2 >= 4.0.39
-BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite
+BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools
 # for install task
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)

--- a/package/yast2-rdp.spec
+++ b/package/yast2-rdp.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-rdp
-Version:        4.1.0
+Version:        4.1.1
 Release:        0
 License:        GPL-2.0-only
 Group:          System/YaST
@@ -26,7 +26,7 @@ Source0:        %{name}-%{version}.tar.bz2
 BuildArch:      noarch
 # SuSEFirewall2 replaced by firewalld (fate#323460)
 BuildRequires:  yast2 >= 4.0.39
-BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite yast2-network
+BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite
 BuildRequires:  yast2-devtools
 # for install task
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)

--- a/src/include/rdp/dialogs.rb
+++ b/src/include/rdp/dialogs.rb
@@ -15,8 +15,6 @@ module Yast
       Yast.import "Label"
       Yast.import "RDP"
       Yast.import "Wizard"
-
-      Yast.include include_target, "network/routines.rb"
     end
 
     # Remote administration dialog


### PR DESCRIPTION
## Problem

Apparently, this module depends on yast2-network only because a convenience method for going next in the Progress Dialog and for modifying the progress title.

- https://trello.com/c/jCkIXvH7/838-stop-using-network-routines-in-other-modules

## Solution

- Adapted the code removing the dependency, and also some build dependencies that are not needed anymore.

## Note

These changes will go to SP2, so the changes will be added to a feature branch which should be merged in master later.
