### PR TITLE
 Remove network dependency (bsc#1142282)

### DIFF
--- a/package/yast2-rdp.changes
+++ b/package/yast2-rdp.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 22 10:05:05 UTC 2019 - knut.anderssen@suse.com
+
+- Remove network dependency completely
+- 4.0.2.1
+
+-------------------------------------------------------------------
 Tue Jun 26 16:27:44 CEST 2018 - schubi@suse.de
 
 - Added additional searchkeys to desktop file (fate#321043).

--- a/package/yast2-rdp.spec
+++ b/package/yast2-rdp.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-rdp
-Version:        4.0.2
+Version:        4.0.2.1
 Release:        0
 License:        GPL-2.0
 Group:          System/YaST

--- a/package/yast2-rdp.spec
+++ b/package/yast2-rdp.spec
@@ -26,7 +26,7 @@ Source0:        %{name}-%{version}.tar.bz2
 BuildArch:      noarch
 # SuSEFirewall2 replaced by firewalld (fate#323460)
 BuildRequires:  yast2 >= 4.0.39
-BuildRequires:  perl-XML-Writer update-desktop-files yast2-testsuite yast2-network
+BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools
 # for install task
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)

--- a/src/include/rdp/dialogs.rb
+++ b/src/include/rdp/dialogs.rb
@@ -15,8 +15,6 @@ module Yast
       Yast.import "Label"
       Yast.import "RDP"
       Yast.import "Wizard"
-
-      Yast.include include_target, "network/routines.rb"
     end
 
     # Remote administration dialog


### PR DESCRIPTION
The dependency exists only because the `ProgressNextStage` convenience method include with 'network/routines' 

We already planned to drop it in SP2 (#17), but as consequence of the reported bug it probably makes sense to drop since GA version in advance.